### PR TITLE
after-install-linux: unset NIX_REMOTE

### DIFF
--- a/after-install-linux.sh
+++ b/after-install-linux.sh
@@ -4,6 +4,7 @@ set -e
 storedir=/nix/store
 localstatedir=/nix/var/nix
 nix=/opt/nix-multiuser/nix
+unset NIX_REMOTE
 
 # Setup build users
 if ! getent group "nixbld" >/dev/null; then


### PR DESCRIPTION
If root has NIX_REMOTE set while running dpkg,
nix-related command will try to connect to the nix-daemon
that we have stopped before.